### PR TITLE
Fix card size

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -59,8 +59,8 @@ html {
 
 .card {
   border-radius: 15px;
-  height: 240px;
-  width: 388px;
+  height: 252px;
+  width: 400px;
   background: #E2E2E2;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The current card size seems to be a little smaller than needed: [the card number doesn't fit in the input](http://i.imgur.com/XLS378O.png). Width and height proportions [differ a bit](https://en.wikipedia.org/wiki/ATM_card#Dimensions) as well.
So I changed the card size from 388x240 to 400x252 and now it looks like [this](http://i.imgur.com/McIkZQV.png).
